### PR TITLE
Fix Mapster strongly-typed ID to Guid mapping

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,16 @@
       "Bash(git add:*)",
       "Bash(git commit -m \"$\\(cat <<''EOF''\nFix EntityFramework namespace typo and add ViewModels project\n\nRenamed EntityFramwork folder to EntityFramework and updated all references.\nAdded Application.ViewModels project, GetBudgets API endpoint, CurrencyService,\nand EF configurations.\n\nCo-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>\nEOF\n\\)\")",
       "Bash(git push)",
-      "Bash(git commit:*)"
+      "Bash(git commit:*)",
+      "Bash(git checkout:*)",
+      "Bash(git pull:*)",
+      "Bash(dotnet test:*)",
+      "Bash(git stash:*)",
+      "Bash(git push:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh issue create --title \"Fix Mapster BudgetId to Guid mapping test failure\" --body \"$\\(cat <<''EOF''\n## Problem\nThe test `BudgetModelTests.Map_From_Aggregate_To_Model_Successfully` is failing due to a Mapster configuration issue.\n\n## Error\n```\nMapster.CompileException: Cannot convert immutable type, please consider using ''MapWith'' method to create mapping\nsource=BlazingBudget.Domain.Aggregates.Budgets.BudgetId\ndestination=System.Guid\n```\n\n## Solution\nConfigure Mapster to handle strongly-typed ID conversions:\n- Add a `MapWith` configuration for `BudgetId` → `Guid`\n- Consider creating a global Mapster configuration for all strongly-typed IDs\n\n## Acceptance Criteria\n- [ ] All tests pass\n- [ ] Mapster configuration handles all strongly-typed IDs in the project\nEOF\n\\)\")",
+      "Bash(gh issue create --title \"Set up database connection for development\" --body \"$\\(cat <<''EOF''\n## Goal\nConfigure a database connection string so EF Core migrations and database operations work end-to-end.\n\n## Tasks\n- [ ] Add connection string to `appsettings.Development.json`\n- [ ] Verify `BudgetContext` can connect to the database\n- [ ] Run initial migration \\(if not already done\\)\n- [ ] Test basic CRUD operations\n\n## Options\n1. **SQL Server LocalDB** - Zero setup on Windows\n2. **SQLite** - Portable, no server needed\n3. **PostgreSQL** - Production-ready option\n4. **SQL Server \\(Docker\\)** - Matches production environments\n\n## Notes\nThis enables Claude to test database operations and verify EF configurations work correctly.\nEOF\n\\)\")",
+      "Bash(gh issue create:*)"
     ]
   }
 }

--- a/src/Application/BlazingBudget.Application/Mapping/MapsterConfiguration.cs
+++ b/src/Application/BlazingBudget.Application/Mapping/MapsterConfiguration.cs
@@ -1,0 +1,63 @@
+using BlazingBudget.Domain.Aggregates.Accounts;
+using BlazingBudget.Domain.Aggregates.Budgets;
+using BlazingBudget.Domain.Aggregates.Debts;
+using Mapster;
+
+namespace BlazingBudget.Application.Mapping;
+
+/// <summary>
+/// Configures Mapster type adapters for strongly-typed IDs and other custom mappings.
+/// </summary>
+public static class MapsterConfiguration
+{
+	/// <summary>
+	/// Registers all custom type mappings. Call this at application startup.
+	/// </summary>
+	public static void Configure()
+	{
+		ConfigureStronglyTypedIds();
+	}
+
+	private static void ConfigureStronglyTypedIds()
+	{
+		// BudgetId <-> Guid
+		TypeAdapterConfig<BudgetId, Guid>.NewConfig()
+			.MapWith(src => src.Value);
+		TypeAdapterConfig<Guid, BudgetId>.NewConfig()
+			.MapWith(src => new BudgetId(src));
+
+		// AccountId <-> Guid
+		TypeAdapterConfig<AccountId, Guid>.NewConfig()
+			.MapWith(src => src.Value);
+
+		// ExpenseId <-> Guid
+		TypeAdapterConfig<ExpenseId, Guid>.NewConfig()
+			.MapWith(src => src.Value);
+		TypeAdapterConfig<Guid, ExpenseId>.NewConfig()
+			.MapWith(src => new ExpenseId(src));
+
+		// IncomeId <-> Guid
+		TypeAdapterConfig<IncomeId, Guid>.NewConfig()
+			.MapWith(src => src.Value);
+		TypeAdapterConfig<Guid, IncomeId>.NewConfig()
+			.MapWith(src => new IncomeId(src));
+
+		// PaymentId <-> Guid
+		TypeAdapterConfig<PaymentId, Guid>.NewConfig()
+			.MapWith(src => src.Value);
+		TypeAdapterConfig<Guid, PaymentId>.NewConfig()
+			.MapWith(src => new PaymentId(src));
+
+		// DebtId <-> Guid
+		TypeAdapterConfig<DebtId, Guid>.NewConfig()
+			.MapWith(src => src.Value);
+		TypeAdapterConfig<Guid, DebtId>.NewConfig()
+			.MapWith(src => new DebtId(src));
+
+		// DebtPaymentId <-> Guid
+		TypeAdapterConfig<DebtPaymentId, Guid>.NewConfig()
+			.MapWith(src => src.Value);
+		TypeAdapterConfig<Guid, DebtPaymentId>.NewConfig()
+			.MapWith(src => new DebtPaymentId(src));
+	}
+}

--- a/src/Application/BlazingBudget.Application/ServiceCollectionExtensions.cs
+++ b/src/Application/BlazingBudget.Application/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using BlazingBudget.Application.PipelineBehaviors;
+﻿using BlazingBudget.Application.Mapping;
+using BlazingBudget.Application.PipelineBehaviors;
 using FastEndpoints;
 using Mediator;
 using Microsoft.Extensions.DependencyInjection;
@@ -8,6 +9,8 @@ public static class ServiceCollectionExtensions
 {
     public static IServiceCollection AddApplication(this IServiceCollection services)
     {
+		MapsterConfiguration.Configure();
+
 		services.AddFastEndpoints();
 
 		services.AddMediator(

--- a/tests/BlazingBudget.Application.Tests/BudgetModelTests.cs
+++ b/tests/BlazingBudget.Application.Tests/BudgetModelTests.cs
@@ -1,4 +1,5 @@
 using BlazingBudget.Application.Budgets.UpsertBudgets;
+using BlazingBudget.Application.Mapping;
 using BlazingBudget.Domain.Aggregates.Accounts;
 using BlazingBudget.Domain.Aggregates.Budgets;
 using BlazingBudget.Domain.ValueObjects;
@@ -8,6 +9,11 @@ namespace BlazingBudget.Application.Tests
 {
     public class BudgetModelTests
     {
+        public BudgetModelTests()
+        {
+            MapsterConfiguration.Configure();
+        }
+
         [Fact]
         public void Map_From_Aggregate_To_Model_Successfully()
         {


### PR DESCRIPTION
## Summary
Fixes the failing `Map_From_Aggregate_To_Model_Successfully` test by configuring Mapster to handle strongly-typed ID conversions.

## Changes
- Added `MapsterConfiguration` class with type converters for all strongly-typed IDs
- Integrated configuration into `AddApplication()` for runtime use
- Added configuration call in test constructor

## Strongly-typed IDs configured
- `BudgetId` ↔ `Guid`
- `AccountId` → `Guid`
- `ExpenseId` ↔ `Guid`
- `IncomeId` ↔ `Guid`
- `PaymentId` ↔ `Guid`
- `DebtId` ↔ `Guid`
- `DebtPaymentId` ↔ `Guid`

## Test plan
- [x] Build passes (0 errors)
- [x] All tests pass (6/6)
  - TUnit: 3 passed
  - Domain: 2 passed
  - Application: 1 passed ✅ (previously failing)

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)