### PR TITLE
Refactor Domain project to organize types by Aggregate

### DIFF
--- a/src/Domain/BlazingBudget.Domain/Aggregates/Accounts/Account.cs
+++ b/src/Domain/BlazingBudget.Domain/Aggregates/Accounts/Account.cs
@@ -1,6 +1,4 @@
-﻿using BlazingBudget.Domain.ValueObjects;
-
-namespace BlazingBudget.Domain.Aggregates.Accounts;
+﻿namespace BlazingBudget.Domain.Aggregates.Accounts;
 public sealed class Account : Entity<AccountId>
 {
 	public PersonName Name { get; private set; }

--- a/src/Domain/BlazingBudget.Domain/Aggregates/Accounts/Email.cs
+++ b/src/Domain/BlazingBudget.Domain/Aggregates/Accounts/Email.cs
@@ -1,7 +1,7 @@
-﻿using CSharpFunctionalExtensions;
+using CSharpFunctionalExtensions;
 using BlazingBudget.Domain.Common;
 
-namespace BlazingBudget.Domain.ValueObjects
+namespace BlazingBudget.Domain.Aggregates.Accounts
 {
     public class Email : ValueObject
     {

--- a/src/Domain/BlazingBudget.Domain/Aggregates/Accounts/Password.cs
+++ b/src/Domain/BlazingBudget.Domain/Aggregates/Accounts/Password.cs
@@ -1,6 +1,6 @@
-﻿using CSharpFunctionalExtensions;
+using CSharpFunctionalExtensions;
 
-namespace BlazingBudget.Domain.ValueObjects;
+namespace BlazingBudget.Domain.Aggregates.Accounts;
 
     public class Password : ValueObject
     {

--- a/src/Domain/BlazingBudget.Domain/Aggregates/Accounts/PersonName.cs
+++ b/src/Domain/BlazingBudget.Domain/Aggregates/Accounts/PersonName.cs
@@ -1,6 +1,6 @@
-﻿using CSharpFunctionalExtensions;
+using CSharpFunctionalExtensions;
 
-namespace BlazingBudget.Domain.ValueObjects;
+namespace BlazingBudget.Domain.Aggregates.Accounts;
 public class PersonName : ValueObject
 {
     public string FirstName { get; private set; }
@@ -11,7 +11,7 @@ public class PersonName : ValueObject
     public string FullName => $"{FirstName} {LastName}";
 
     public static readonly int MaxLength = 300;
-        
+
     private PersonName() { }
 
     [JsonConstructor]

--- a/src/Domain/BlazingBudget.Domain/Aggregates/Budgets/BudgetCalculator.cs
+++ b/src/Domain/BlazingBudget.Domain/Aggregates/Budgets/BudgetCalculator.cs
@@ -1,12 +1,6 @@
-﻿using BlazingBudget.Domain.Aggregates.Budgets;
 using CSharpFunctionalExtensions;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace BlazingBudget.Domain.Services
+namespace BlazingBudget.Domain.Aggregates.Budgets
 {
     internal class BudgetCalculator
     {

--- a/src/Domain/BlazingBudget.Domain/Aggregates/Debts/MoneyOwed.cs
+++ b/src/Domain/BlazingBudget.Domain/Aggregates/Debts/MoneyOwed.cs
@@ -1,6 +1,7 @@
-﻿using CSharpFunctionalExtensions;
+using CSharpFunctionalExtensions;
+using BlazingBudget.Domain.ValueObjects;
 
-namespace BlazingBudget.Domain.ValueObjects;
+namespace BlazingBudget.Domain.Aggregates.Debts;
 /// <summary>
 /// Money owed is an amount of money still left to pay.
 /// </summary>

--- a/src/Domain/BlazingBudget.Domain/Aggregates/Debts/MoneyPaid.cs
+++ b/src/Domain/BlazingBudget.Domain/Aggregates/Debts/MoneyPaid.cs
@@ -1,5 +1,6 @@
-﻿
-namespace BlazingBudget.Domain.ValueObjects;
+using BlazingBudget.Domain.ValueObjects;
+
+namespace BlazingBudget.Domain.Aggregates.Debts;
 /// <summary>
 /// Money paid is an amount of money paid.
 /// </summary>


### PR DESCRIPTION
Fixes #12

Reorganized the Domain project structure to follow DDD principles more closely by moving aggregate-specific types into their respective aggregate folders:

### Changes

**Account Aggregate:**
- Moved PersonName, Email, Password value objects

**Budgets Aggregate:**
- Moved BudgetCalculator service

**Debts Aggregate:**
- Moved MoneyOwed, MoneyPaid value objects

Shared types (Money, Currency, Address, etc.) remain in their current locations as they are used across multiple aggregates.

### Verification

- ✅ Build successful
- ✅ All tests passing (6/6)
- ✅ No breaking changes

🤖 Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/mohaaron/BlazingBudget/actions/runs/21568096182